### PR TITLE
Atualização das actions de gerar release

### DIFF
--- a/.github/workflows/release-ci-homolog.yml
+++ b/.github/workflows/release-ci-homolog.yml
@@ -2,7 +2,7 @@ name: Generate Release
 on:
   push:
     branches:
-      - main
+      - devel
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -45,4 +45,5 @@ jobs:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
+          prerelease: true
           artifacts: ${{ steps.report.outputs.report_file_name }}.json

--- a/.github/workflows/release-ci-homolog.yml
+++ b/.github/workflows/release-ci-homolog.yml
@@ -1,4 +1,5 @@
 name: Generate Release
+
 on:
   push:
     branches:
@@ -27,7 +28,7 @@ jobs:
             SONAR_URL: ${{ secrets.SONAR_URL }}
 
       - name: Pushes sonar file
-        uses: dmnemec/copy_file_to_another_repo_action@main
+        uses: dmnemec/copy_file_to_another_repo_action@v1.1.1
         env:
           API_TOKEN_GITHUB: ${{ secrets.GIT_TOKEN }}
         with:

--- a/.github/workflows/release-ci-prod.yml
+++ b/.github/workflows/release-ci-prod.yml
@@ -1,8 +1,9 @@
 name: Set Release
+
 on:
   push:
-  branches:
-    - main
+    branches:
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-ci-prod.yml
+++ b/.github/workflows/release-ci-prod.yml
@@ -1,0 +1,26 @@
+name: Set Release
+on:
+  push:
+  branches:
+    - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get last prerelease
+        id: last_release
+        uses: InsonusK/get-latest-release@v1.0.1
+        with:
+          myToken: ${{ secrets.GITHUB_TOKEN }}
+          exclude_types: "draft|release"
+
+      - name: Update prerelease to release
+        run: |
+          curl \
+          -u user:${{ secrets.GIT_TOKEN }} \
+          -X PATCH \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/fga-eps-mds/${{github.event.repository.name}}/releases/${{ steps.last_release.outputs.id }} \
+          -d '{"prerelease": "false"}'


### PR DESCRIPTION
Resolve [#132](https://github.com/fga-eps-mds/2021.1-Pro-Especies-Docs/issues/132)

Atualização da action que gera release e criação da action para atualizar a pre-release.